### PR TITLE
feat(web): rebuild the Modes page as a Betaflight-style range slider

### DIFF
--- a/app/web/app.js
+++ b/app/web/app.js
@@ -307,6 +307,101 @@ document.addEventListener('alpine:init', () => {
     },
   });
 
+  // Dual-handle range slider over two config keys, built from plain elements
+  // so the track, the selected-range fill and the ruler are all styleable.
+  // Args: the µs bounds, the [minKey, maxKey] pair it edits (null for a
+  // function that has no range), and the config key naming its RC channel.
+  Alpine.data('rangeSlider', (min, max, keys, channelKey) => ({
+    min,
+    max,
+    keys,
+    channelKey,
+    dragging: null,
+
+    // A row with no range still draws its track, ruler and live marker --
+    // only the fill and the two handles need a range to exist.
+    get hasRange() {
+      return !!this.keys;
+    },
+    get enabled() {
+      return this.hasRange && this.$store.app.connected;
+    },
+    get lo() {
+      return this.hasRange ? Number(this.$store.config.values[this.keys[0]]) : this.min;
+    },
+    get hi() {
+      return this.hasRange ? Number(this.$store.config.values[this.keys[1]]) : this.max;
+    },
+    pct(v) {
+      return ((v - this.min) / (this.max - this.min)) * 100;
+    },
+
+    // Where the RC stick currently sits, so the marker tracks the radio. The
+    // channel may be unset ("none") or the board may be sending nothing yet;
+    // mid-stick is the neutral standing in for "no reading".
+    get live() {
+      const v = this.$store.telemetry.raw[this.$store.config.values[this.channelKey]];
+      return typeof v === 'number' ? v : 1500;
+    },
+    // Clamped: a receiver may legally read outside the slider's own bounds.
+    get livePct() {
+      return Math.min(Math.max(this.pct(this.live), 0), 100);
+    },
+
+    // A labelled tick every tenth, drawn taller at both ends and the midpoint.
+    get ticks() {
+      const span = this.max - this.min;
+      const out = [];
+      for (let v = this.min; v <= this.max; v += span / 10) {
+        out.push({ v: Math.round(v), major: (v - this.min) % (span / 2) === 0 });
+      }
+      return out;
+    },
+
+    valueAt(clientX) {
+      const r = this.$refs.track.getBoundingClientRect();
+      const t = Math.min(Math.max((clientX - r.left) / r.width, 0), 1);
+      return Math.round(this.min + t * (this.max - this.min));
+    },
+
+    // The thumb keeps pointer capture for the whole drag, so move/up keep
+    // firing on it after the pointer has left its 1rem box.
+    down(e, which) {
+      if (!this.enabled) return;
+      this.dragging = which;
+      e.target.setPointerCapture(e.pointerId);
+    },
+    move(e) {
+      if (this.dragging === null) return;
+      this.apply(this.dragging, this.valueAt(e.clientX));
+    },
+    up() {
+      if (this.dragging === null) return;
+      const which = this.dragging;
+      this.dragging = null;
+      this.push(which);
+    },
+
+    // Held inside the µs bounds first (a keyboard nudge has no track to clamp
+    // it against), then against the other handle: the two may meet, never cross.
+    apply(which, v) {
+      const inRange = Math.min(Math.max(v, this.min), this.max);
+      const bounded = which === 0
+        ? Math.min(inRange, this.hi)
+        : Math.max(inRange, this.lo);
+      this.$store.config.values[this.keys[which]] = bounded;
+    },
+    push(which) {
+      const def = this.$store.config.field(this.keys[which]).def;
+      if (def) this.$store.config.commit(def);
+    },
+    nudge(which, delta) {
+      if (!this.enabled) return;
+      this.apply(which, (which === 0 ? this.lo : this.hi) + delta);
+      this.push(which);
+    },
+  }));
+
   Alpine.store('telemetry', {
     schema: [],
     data: {},
@@ -936,7 +1031,10 @@ async function showPage(page) {
   const generation = ++showPageGeneration;
   let html = pageCache.get(page);
   if (html === undefined) {
-    const r = await fetch(`pages/${page}.html`);
+    // 'no-cache' revalidates rather than serving from the HTTP cache: a
+    // fragment held there while index.html/app.js reload is markup skewed
+    // against the CSS and components it relies on. A 304 costs nothing here.
+    const r = await fetch(`pages/${page}.html`, { cache: 'no-cache' });
     if (!r.ok) {
       showError(`Failed to load the ${page} page (${r.status})`);
       return;

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -82,22 +82,63 @@
     .tank-hero { height: 340px; overflow: hidden; border-radius: .5rem; margin-bottom: 1rem; background: #13230f; }
     .tank-hero img { width: 100%; height: 100%; object-fit: contain; display: block; }
 
-    /* Modes page: a dual-handle range built from TWO overlapping native
-       .form-range inputs (the same template led.blink_hz/servo.angle use).
-       pointer-events: none on both, restored to auto only on each one's own
-       thumb pseudo-element, is what lets each thumb be dragged independently
-       despite sharing the same screen space -- the standard technique for a
-       two-handle range slider built from native inputs. Only the FIRST
-       input's track stays visible; the second's is made transparent so the
-       two don't visually double up into two overlapping bars. */
-    .mode-slider { position: relative; height: 1.5rem; }
-    .mode-slider input[type="range"] {
-      position: absolute; left: 0; top: 0; width: 100%; margin: 0; pointer-events: none;
+    /* Modes page: one row per function -- a name plate, its channel select,
+       then the slider. Rows sit in a single panel, split only by margin. */
+    .mode-row + .mode-row { margin-top: 1.75rem; }
+    .mode-name {
+      flex: 0 0 11rem; padding: .5rem;
+      border: 1px solid var(--bs-border-color); border-radius: .375rem;
+      background: var(--bs-tertiary-bg);
     }
-    .mode-slider input[type="range"]::-webkit-slider-thumb { pointer-events: auto; }
-    .mode-slider input[type="range"]::-moz-range-thumb { pointer-events: auto; }
-    .mode-slider input[type="range"]:nth-of-type(2)::-webkit-slider-runnable-track { background: transparent; }
-    .mode-slider input[type="range"]:nth-of-type(2)::-moz-range-track { background: transparent; }
+    .mode-title {
+      font-size: .8125rem; font-weight: 700; text-align: center;
+      letter-spacing: .04em; text-transform: uppercase;
+    }
+    .mode-channel { flex: 0 0 8rem; }
+
+    /* Dual-handle range slider (the `rangeSlider` Alpine component). Built
+       from plain elements rather than native range inputs, whose track can
+       only be reached through vendor pseudo-elements -- --range-accent colors
+       the fill and both handles as one. The side padding is what lets the end
+       labels centre on their own ticks rather than tuck inside the track. */
+    .range-slider { --range-accent: #0d6efd; min-width: 0; padding: 0 1.5rem; }
+    .range-slider-disabled { --range-accent: var(--bs-secondary-color); }
+    .range-track {
+      position: relative; height: .5rem; margin-top: .75rem;
+      background: var(--bs-secondary-bg); border-radius: 1rem;
+    }
+    .range-fill {
+      position: absolute; top: 0; height: 100%;
+      background: var(--range-accent); border-radius: 1rem;
+    }
+    .range-thumb {
+      position: absolute; top: 50%; width: 1.25rem; height: 1.25rem;
+      margin: -.625rem 0 0 -.625rem; background: var(--bs-body-bg);
+      border: 3px solid var(--range-accent); border-radius: 50%;
+      cursor: grab; touch-action: none;
+    }
+    .range-thumb:active { cursor: grabbing; }
+    .range-thumb:focus-visible { outline: 0; box-shadow: 0 0 0 .25rem rgba(13, 110, 253, .25); }
+    .range-slider-disabled .range-thumb { cursor: default; }
+
+    /* Ruler under the track: a tick every tenth, each labelled, with the ends
+       and midpoint drawn taller. Labels centre on their own tick. */
+    .range-ruler { position: relative; height: 1.75rem; margin-top: .5rem; }
+    .range-tick { position: absolute; top: 0; width: 1px; height: .3125rem; background: var(--bs-border-color); }
+    .range-tick-major { height: .5rem; }
+    .range-tick span {
+      position: absolute; top: .625rem; left: 50%; transform: translateX(-50%);
+      font-size: .6875rem; color: var(--bs-secondary-color);
+    }
+
+    /* Live RC position for this function's channel, sitting on the ruler.
+       Keeps its own color so it stays readable on a row with no range. */
+    .range-live {
+      position: absolute; top: -.1875rem; width: .3125rem; height: .875rem;
+      margin-left: -.15625rem; border-radius: .1875rem;
+      background: #0d6efd;
+    }
+    .range-slider-disabled .range-live { background: var(--bs-secondary-color); }
 
     /* Controller page's RC Channel bars: a lighter blue than Bootstrap's
        default .progress-bar so the centered bold-black value stays legible

--- a/app/web/pages/modes.html
+++ b/app/web/pages/modes.html
@@ -1,59 +1,83 @@
           <div class="d-flex justify-content-between flex-wrap align-items-center pt-3 pb-2 mb-3 border-bottom">
             <h1 class="h2">Modes</h1>
           </div>
-          <div x-data="{
+          <fieldset class="card" :disabled="!$store.app.connected" x-data="{
             rows: [
-              { title: 'Arm',       channelKey: 'tank_drive.arm_src',      rangeKeys: ['tank_drive.arm_min', 'tank_drive.arm_max'], directionSelect: false },
               { title: 'Throttle',  channelKey: 'tank_drive.throttle_src', rangeKeys: null, directionSelect: true },
               { title: 'Direction', channelKey: 'tank_drive.steer_src',    rangeKeys: null, directionSelect: false },
+              { title: 'Arm',       channelKey: 'tank_drive.arm_src',      rangeKeys: ['tank_drive.arm_min', 'tank_drive.arm_max'], directionSelect: false },
             ],
           }">
-            <template x-for="row in rows" :key="row.channelKey">
-              <fieldset class="card mb-3" :disabled="!$store.app.connected">
-                <legend class="card-header h6 text-secondary mb-0 py-2" x-text="row.title"></legend>
-                <div class="card-body row g-3 align-items-center">
-                  <div class="col-md-4">
-                    <label class="form-label" :for="'f-' + row.channelKey">Channel</label>
-                    <select class="form-select" :id="'f-' + row.channelKey"
+            <div class="card-body">
+              <template x-for="row in rows" :key="row.channelKey">
+                <div class="mode-row d-flex gap-3 align-items-start">
+                  <div class="mode-name">
+                    <div class="mode-title" x-text="row.title"></div>
+                    <template x-if="row.directionSelect">
+                      <select class="form-select form-select-sm mt-2" aria-label="ESC direction"
+                              x-model="$store.config.values['esc0.direction']"
+                              @change="$store.config.setBothDirections($event.target.value)">
+                        <template x-for="opt in $store.config.field('esc0.direction').def?.options ?? []" :key="opt">
+                          <option :value="opt" :selected="opt === $store.config.values['esc0.direction']" x-text="opt"></option>
+                        </template>
+                      </select>
+                    </template>
+                  </div>
+
+                  <div class="mode-channel">
+                    <select class="form-select form-select-sm" :id="'f-' + row.channelKey"
                             :class="{ 'is-invalid': $store.config.invalid[row.channelKey] }"
+                            :aria-label="row.title + ' channel'"
                             x-model="$store.config.values[row.channelKey]"
                             @change="$store.config.commit($store.config.field(row.channelKey).def)">
                       <template x-for="opt in $store.config.field(row.channelKey).def?.options ?? []" :key="opt">
                         <option :value="opt" :selected="opt === $store.config.values[row.channelKey]" x-text="opt"></option>
                       </template>
                     </select>
+                    <template x-if="row.rangeKeys">
+                      <div class="small text-secondary text-end mt-1">
+                        <div>Min: <span x-text="$store.config.values[row.rangeKeys[0]]"></span></div>
+                        <div>Max: <span x-text="$store.config.values[row.rangeKeys[1]]"></span></div>
+                      </div>
+                    </template>
                   </div>
-                  <div class="col-md-5">
-                    <div class="mode-slider">
-                      <input type="range" class="form-range" min="1000" max="2000" step="1"
-                             :disabled="!row.rangeKeys"
-                             :value="row.rangeKeys ? $store.config.values[row.rangeKeys[0]] : 1000"
-                             @input="row.rangeKeys && ($store.config.values[row.rangeKeys[0]] =
-                               Math.min(Number($event.target.value), Number($store.config.values[row.rangeKeys[1]])))"
-                             @change="row.rangeKeys && $store.config.commit($store.config.field(row.rangeKeys[0]).def)">
-                      <input type="range" class="form-range" min="1000" max="2000" step="1"
-                             :disabled="!row.rangeKeys"
-                             :value="row.rangeKeys ? $store.config.values[row.rangeKeys[1]] : 2000"
-                             @input="row.rangeKeys && ($store.config.values[row.rangeKeys[1]] =
-                               Math.max(Number($event.target.value), Number($store.config.values[row.rangeKeys[0]])))"
-                             @change="row.rangeKeys && $store.config.commit($store.config.field(row.rangeKeys[1]).def)">
-                    </div>
-                    <div class="text-secondary small mt-1" x-show="row.rangeKeys">
-                      <span x-text="row.rangeKeys ? $store.config.values[row.rangeKeys[0]] : ''"></span>–<span x-text="row.rangeKeys ? $store.config.values[row.rangeKeys[1]] : ''"></span> µs
-                    </div>
-                  </div>
-                  <div class="col-md-3" x-show="row.directionSelect">
-                    <label class="form-label" for="f-esc-direction">Direction</label>
-                    <select class="form-select" id="f-esc-direction"
-                            x-model="$store.config.values['esc0.direction']"
-                            @change="$store.config.setBothDirections($event.target.value)">
-                      <template x-for="opt in $store.config.field('esc0.direction').def?.options ?? []" :key="opt">
-                        <option :value="opt" :selected="opt === $store.config.values['esc0.direction']" x-text="opt"></option>
+
+                  <div class="range-slider flex-grow-1"
+                       :class="{ 'range-slider-disabled': !$store.app.connected }"
+                       x-data="rangeSlider(1000, 2000, row.rangeKeys, row.channelKey)">
+                    <div class="range-track" x-ref="track">
+                      <div class="range-fill" x-show="hasRange"
+                           :style="`left:${pct(lo)}%; width:${pct(hi) - pct(lo)}%`"></div>
+                      <template x-for="which in (hasRange ? [0, 1] : [])" :key="which">
+                        <div class="range-thumb" role="slider"
+                             :style="`left:${pct(which === 0 ? lo : hi)}%`"
+                             :tabindex="enabled ? 0 : -1"
+                             :aria-label="which === 0 ? 'Range minimum' : 'Range maximum'"
+                             :aria-valuemin="min" :aria-valuemax="max"
+                             :aria-valuenow="which === 0 ? lo : hi"
+                             @pointerdown="down($event, which)"
+                             @pointermove="move($event)"
+                             @pointerup="up()"
+                             @keydown.arrow-left.prevent="nudge(which, -1)"
+                             @keydown.arrow-down.prevent="nudge(which, -1)"
+                             @keydown.arrow-right.prevent="nudge(which, 1)"
+                             @keydown.arrow-up.prevent="nudge(which, 1)"
+                             @keydown.page-down.prevent="nudge(which, -50)"
+                             @keydown.page-up.prevent="nudge(which, 50)"></div>
                       </template>
-                    </select>
+                    </div>
+                    <div class="range-ruler">
+                      <template x-for="tick in ticks" :key="tick.v">
+                        <div class="range-tick" :class="{ 'range-tick-major': tick.major }"
+                             :style="`left:${pct(tick.v)}%`">
+                          <span x-text="tick.v"></span>
+                        </div>
+                      </template>
+                      <div class="range-live" :style="`left:${livePct}%`" :title="live + ' µs'"></div>
+                    </div>
                   </div>
                 </div>
-              </fieldset>
-            </template>
-          </div>
+              </template>
+            </div>
+          </fieldset>
           <p>&nbsp;</p>


### PR DESCRIPTION
Rebuilds the Modes page around a real dual-handle range slider and a Betaflight-style layout.

## Why

The old control was two overlapping native `<input type=range>` elements. A native range's track can only be painted through vendor pseudo-elements (`::-webkit-slider-runnable-track` / `::-moz-range-track`), which is why the selected-range fill repeatedly failed to render. An ordinary element cannot fail that way.

## What changed

**`rangeSlider`, a new Alpine component** (`app.js`) built from plain elements — track, fill, handles, ruler and live marker are all directly styleable, sharing one `--range-accent`.

**Single panel, one row per function** — name plate, channel select, slider — separated by margin rather than each function owning its own card. Order is Throttle, Direction, Arm. Throttle carries the shared `esc0`/`esc1` direction select in its name plate; Arm shows Min/Max under its channel select.

**Ruler and live RC marker** — a labelled tick every 100µs, drawn taller at 1000/1500/2000. Each row shows a live marker tracking its own channel from `$store.telemetry.raw`, so sticks can be checked against the range on every function. Throttle and Direction have no range parameters in the firmware schema, so they draw track, ruler and marker but no fill or handles — which is what lets you watch the stick move on those rows too.

**Fragment caching fix** — page fragments are now fetched with `cache: 'no-cache'`. A fragment served from the HTTP cache while `index.html`/`app.js` reload is markup skewed against the CSS and components it depends on, which renders as visibly broken UI.

## Correctness details

- Values are clamped inside the µs bounds *before* being clamped against the other handle. A keyboard nudge has no track to clamp it against, and without this PageUp drove the max to 2049µs — an out-of-range value the firmware would reject.
- The two handles may meet but never cross.
- The live marker clamps to the track: a receiver may legally read outside 1000–2000.
- It falls back to mid-stick (1500) when the channel is unset (`none`) or no frame has arrived.
- Handles keep the keyboard access the native inputs had: focusable, arrows ±1µs, PageUp/PageDown ±50µs, `role="slider"` with `aria-value*` kept in sync, `tabindex` dropping to -1 when disconnected.
- Muting now tracks connection state rather than "has a range", so a disconnected row greys out consistently.

## Verification

No automated UI suite exists by design, so this was driven headlessly (Playwright) against a fake device:

- Live marker: 1500 with no rx; `ch1=1250 ch2=1750 ch5=2000` → 25% / 75% / 100%; out-of-range 900/2100 → 0% / 100%; re-points when a row's channel changes.
- Drag: Arm low handle to 40% → 1400, fill `left:40%; width:60%`.
- Keyboard: arrows and PageUp/PageDown move and clamp correctly; no `invalid` flags, so every write was accepted by backend validation.
- Ruler: 11 labels, majors at 0/50/100%, end labels centred on their ticks (615 vs track left 614; 1216 vs track right 1215), 28px clear of the panel border, no label overlap at 1280px or 1024px.
- No console errors in any state. 237 backend tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)