### PR TITLE
Add Apache and Docker/Caddy hosting options for web-app

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Copy to .env and adjust for your deployment. .env itself is gitignored.
+
+# Caddy site address. ":80" serves plain HTTP on any hostname, for sitting
+# behind a TLS-terminating reverse proxy (e.g. another Caddy instance
+# fronting a domain name). Set a real hostname instead (e.g. raspi3.local)
+# to have Caddy self-sign and serve HTTPS directly.
+SERVER_NAME=:80
+
+# Host ports Caddy's listeners are published on. Change these if 80/443 are
+# already in use on the host. WEB_HTTPS_PORT is only used when SERVER_NAME
+# above is a real hostname (self-signed HTTPS mode).
+WEB_HTTP_PORT=80
+WEB_HTTPS_PORT=443

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,10 @@ site/
 _autosave-*
 fp-info-cache
 
+# Docker hosting config: per-deployment secrets/ports, not source. .env.example
+# documents the variables and is committed.
+.env
+
 # Editor / OS
 .vscode/
 .DS_Store

--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,6 @@
+# Serves web-app/ at the site root when this repo is cloned directly into
+# Apache's DocumentRoot. Requests are rewritten into web-app/ internally, so
+# paths outside that folder (firmware/, app/, hardware/, etc.) 404.
+RewriteEngine On
+RewriteCond %{REQUEST_URI} !^/web-app/
+RewriteRule ^(.*)$ /web-app/$1 [L]

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,7 @@
+{$SERVER_NAME} {
+	root * /srv
+	file_server
+
+	@service_worker path /service-worker.js
+	header @service_worker Cache-Control "no-cache"
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+services:
+  caddy:
+    image: caddy:2-alpine
+    restart: unless-stopped
+    ports:
+      - "${WEB_HTTP_PORT:-80}:80"
+      - "${WEB_HTTPS_PORT:-443}:443"
+    environment:
+      - SERVER_NAME=${SERVER_NAME:-:80}
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - ./web-app:/srv:ro
+      - caddy_data:/data
+      - caddy_config:/config
+
+volumes:
+  caddy_data:
+  caddy_config:

--- a/web-app/.htaccess
+++ b/web-app/.htaccess
@@ -1,0 +1,10 @@
+# Content-specific serving rules for this static site.
+<IfModule mod_headers.c>
+	<Files "service-worker.js">
+		Header set Cache-Control "no-cache"
+	</Files>
+</IfModule>
+
+<Files "manifest.json">
+	ForceType application/manifest+json
+</Files>


### PR DESCRIPTION
## Summary
- Root `.htaccess` rewrites non-`/web-app/` requests into `web-app/`, so cloning the repo into an Apache vhost's DocumentRoot serves the static site at the root without exposing `firmware/`, `app/`, `hardware/`, etc. `web-app/.htaccess` sets `no-cache` on `service-worker.js` and the correct `manifest.json` content type.
- `docker-compose.yml` + `Caddyfile` serve `web-app/` via Caddy, configurable through a gitignored `.env` (`.env.example` committed). `SERVER_NAME` defaults to `:80` (plain HTTP, for sitting behind a TLS-terminating reverse proxy); setting it to a real hostname switches Caddy to self-signed HTTPS directly.

## Test plan
- [x] `httpd:2.4-alpine` container against the repo: `/` and `/js/api.js` return 200, `/app/backend/main.py` 404s, `/service-worker.js` returns `Cache-Control: no-cache`, `/manifest.json` returns `application/manifest+json`
- [x] `docker compose up` with `SERVER_NAME=:80`: plain HTTP serves the app with no redirect, `service-worker.js` header correct, port 443 unused as expected
- [x] `docker compose up` with a hostname `SERVER_NAME`: self-signed HTTPS mode verified (redirect from 80, valid response on 443)
- [x] `docker compose config` validates cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)